### PR TITLE
make it version independent

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 ARG IMAGE=intersystemsdc/iris-community
 ARG IMAGE=store/intersystems/iris-community:2021.2.0.617.0
 ARG IMAGE=intersystemsdc/iris-ml-community:2021.2.0.617.0-zpm
+ARG IMAGE=intersystemsdc/iris-ml-community
 FROM $IMAGE
 
 USER root


### PR DESCRIPTION
Error: Invalid Community Edition license, may have exceeded core limit. - Shutting down the system